### PR TITLE
Fix location of Pam's upgraded house in the map

### DIFF
--- a/SDVModTest/UIElements/LocationOfTownsfolk.cs
+++ b/SDVModTest/UIElements/LocationOfTownsfolk.cs
@@ -57,7 +57,7 @@ namespace UIInfoSuite.UIElements
             { "Sewer", new KeyValuePair<int, int>(380, 596) },
             { "WizardHouse", new KeyValuePair<int, int>(196, 352) },
             { "Trailer", new KeyValuePair<int, int>(780, 360) },
-            { "pamHouseUpgrade", new KeyValuePair<int, int>(780, 360) },
+            { "Trailer_Big", new KeyValuePair<int, int>(780, 360) },
             { "Forest", new KeyValuePair<int, int>(80, 272) },
             { "Woods", new KeyValuePair<int, int>(100, 272) },
             { "WitchSwamp", new KeyValuePair<int, int>(0, 0) },


### PR DESCRIPTION
The string key of the location was wrong, resulting in Pam and Penny being displayed in the top left of the map when inside the upgraded house. This pull request simply changes  "pamHouseUpgrade" to "Trailer_Big", as is consistent in the game code.