### PR TITLE
Improve petting indicator animation

### DIFF
--- a/SDVModTest/UIElements/ShowWhenAnimalNeedsPet.cs
+++ b/SDVModTest/UIElements/ShowWhenAnimalNeedsPet.cs
@@ -136,7 +136,9 @@ namespace UIInfoSuite.UIElements
         private void UpdateTicked(object sender, UpdateTickedEventArgs e)
         {
             // Bob up and down in a sin wave each draw
-            _yMovementPerDraw = -6f + 6f * (float)Math.Sin(e.Ticks / 20.0);
+            float sine = (float)Math.Sin(e.Ticks / 20.0);
+            _yMovementPerDraw = -6f + 6f * sine;
+            _alpha = 0.8f + 0.2f * sine;
         }
 
         private void DrawIconForFarmAnimals()
@@ -148,7 +150,8 @@ namespace UIInfoSuite.UIElements
                 foreach (var animal in animalsInCurrentLocation.Pairs)
                 {
                     if (!animal.Value.IsEmoting &&
-                        !animal.Value.wasPet.Value)
+                        !animal.Value.wasPet.Value &&
+                        animal.Value.friendshipTowardFarmer.Value < 1000)
                     {
                         Vector2 positionAboveAnimal = GetPetPositionAboveAnimal(animal.Value);
                         String animalType = animal.Value.type.Value.ToLower();
@@ -181,7 +184,8 @@ namespace UIInfoSuite.UIElements
             foreach (var character in Game1.currentLocation.characters)
             {
                 if (character is Pet &&
-                    !_helper.Reflection.GetField<bool>(character, "wasPetToday").GetValue())
+                    !_helper.Reflection.GetField<bool>(character, "wasPetToday").GetValue() && 
+                    _helper.Reflection.GetField<int>(npc, "friendshipTowardFarmer", true).GetValue() < 1000)
                 {
                     Vector2 positionAboveAnimal = GetPetPositionAboveAnimal(character);
                     positionAboveAnimal.X += 50f;

--- a/SDVModTest/UIElements/ShowWhenAnimalNeedsPet.cs
+++ b/SDVModTest/UIElements/ShowWhenAnimalNeedsPet.cs
@@ -135,8 +135,8 @@ namespace UIInfoSuite.UIElements
         /// <param name="e">The event arguments.</param>
         private void UpdateTicked(object sender, UpdateTickedEventArgs e)
         {
-            // update pet draw
-            _yMovementPerDraw = -4f + 4f * (float)Math.Sin(e.Ticks / 20.0);
+            // Bob up and down in a sin wave each draw
+            _yMovementPerDraw = -6f + 6f * (float)Math.Sin(e.Ticks / 20.0);
         }
 
         private void DrawIconForFarmAnimals()

--- a/SDVModTest/UIElements/ShowWhenAnimalNeedsPet.cs
+++ b/SDVModTest/UIElements/ShowWhenAnimalNeedsPet.cs
@@ -13,26 +13,22 @@ namespace UIInfoSuite.UIElements
 {
     class ShowWhenAnimalNeedsPet : IDisposable
     {
-        private readonly Timer _timer = new Timer();
-        private float _yMovementPerDraw;
-        private float _alpha;
+        private float _yMovementPerDraw = 0f;
+        private float _alpha = 1f;
         private readonly IModHelper _helper;
 
         public ShowWhenAnimalNeedsPet(IModHelper helper)
         {
-            _timer.Elapsed += StartDrawingPetNeeds;
             _helper = helper;
         }
 
         public void ToggleOption(bool showWhenAnimalNeedsPet)
         {
-            _timer.Stop();
             _helper.Events.Player.Warped -= OnWarped;
             _helper.Events.Display.RenderingHud -= OnRenderingHud_DrawAnimalHasProduct;
 
             if (showWhenAnimalNeedsPet)
             {
-                _timer.Start();
                 _helper.Events.Player.Warped += OnWarped;
                 _helper.Events.Display.RenderingHud += OnRenderingHud_DrawAnimalHasProduct;
             }
@@ -101,12 +97,10 @@ namespace UIInfoSuite.UIElements
             {
                 if (e.NewLocation is AnimalHouse || e.NewLocation is Farm)
                 {
-                    _timer.Interval = 1000;
-                    _timer.Start();
+                    StartDrawingPetNeeds();
                 }
                 else
                 {
-                    _timer.Stop();
                     StopDrawingPetNeeds();
                 }
             }
@@ -124,13 +118,10 @@ namespace UIInfoSuite.UIElements
             }
         }
 
-        private void StartDrawingPetNeeds(object sender, ElapsedEventArgs e)
+        private void StartDrawingPetNeeds()
         {
-            _timer.Stop();
             _helper.Events.Display.RenderingHud += OnRenderingHud_DrawNeedsPetTooltip;
             _helper.Events.GameLoop.UpdateTicked += UpdateTicked;
-            _yMovementPerDraw = -3f;
-            _alpha = 1f;
         }
 
         private void StopDrawingPetNeeds()
@@ -145,16 +136,7 @@ namespace UIInfoSuite.UIElements
         private void UpdateTicked(object sender, UpdateTickedEventArgs e)
         {
             // update pet draw
-            if (e.IsMultipleOf(2))
-            {
-                _yMovementPerDraw += 0.3f;
-                _alpha -= 0.014f;
-                if (_alpha < 0.1f)
-                {
-                    StopDrawingPetNeeds();
-                    _timer.Start();
-                }
-            }
+            _yMovementPerDraw = -4f + 4f * (float)Math.Sin(e.Ticks / 20.0);
         }
 
         private void DrawIconForFarmAnimals()


### PR DESCRIPTION
Replaced "repeating fading" animation with a "bobbing up and down" animation with softer fading.

I believe that the fading, big pause, then sudden reappearance of the old animation was irritating and made it difficult to see which animals actually needed petting.

The new animation instead bobs up and down slowly, which I think is pleasing to the eyes and helps identify the animals very easily.

Given that the `_timer` object was now obsolete, I removed it and instead called the `StartDrawingPetNeeds` method inside the `OnWarped` event, consistent with the call of `StopDrawingPetNeeds`.

Additionally, I made it so the indicator is only present when the animal is not at max friendship (below 1000), as already having max friendship would make petting unnecessary. If this behavior is not desired by default, I'd suggest making it a toggleable option in a future pull request.

Hope you like it, thanks.