### PR TITLE
Adjust icon positions when no quest button is present

### DIFF
--- a/SDVModTest/IconHandler.cs
+++ b/SDVModTest/IconHandler.cs
@@ -28,7 +28,7 @@ namespace UIInfoSuite
         public Point GetNewIconPosition()
         {
             int yPos = Game1.options.zoomButtons ? 290 : 260;
-            int xPosition = (int)Tools.GetWidthInPlayArea() - 134 - 46 * _amountOfVisibleIcons;
+            int xPosition = (int)Tools.GetWidthInPlayArea() - 75 - 48 * _amountOfVisibleIcons;
             ++_amountOfVisibleIcons;
             return new Point(xPosition, yPos);
         }

--- a/SDVModTest/IconHandler.cs
+++ b/SDVModTest/IconHandler.cs
@@ -28,7 +28,11 @@ namespace UIInfoSuite
         public Point GetNewIconPosition()
         {
             int yPos = Game1.options.zoomButtons ? 290 : 260;
-            int xPosition = (int)Tools.GetWidthInPlayArea() - 75 - 48 * _amountOfVisibleIcons;
+            int xPosition = (int)Tools.GetWidthInPlayArea() - 70 - 48 * _amountOfVisibleIcons;
+            if (Game1.player.questLog.Any())
+            {
+                x -= 65;
+	        }
             ++_amountOfVisibleIcons;
             return new Point(xPosition, yPos);
         }


### PR DESCRIPTION
When no quests are active, the icon positions remain shifted to the left, which looks a little strange as having no quests means there is a gap.
With this simple change, the icons only shift left when there are currently active quests, and stays in the corner when there are no quests left.