### PR TITLE
Fixed NPE when opening a shop window and not hovering over an Item

### DIFF
--- a/SDVModTest/UIElements/ShopHarvestPrices.cs
+++ b/SDVModTest/UIElements/ShopHarvestPrices.cs
@@ -42,7 +42,8 @@ namespace UIInfoSuite.UIElements
             // draw shop harvest prices
             if (Game1.activeClickableMenu is ShopMenu menu)
             {
-                if (typeof(ShopMenu).GetField("hoveredItem", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(menu) is Item hoverItem)
+                if (typeof(ShopMenu).GetField("hoveredItem", BindingFlags.Instance | BindingFlags.NonPublic) != null &&
+					typeof(ShopMenu).GetField("hoveredItem", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(menu) is Item hoverItem)
                 {
                     String text = string.Empty;
                     bool itemHasPriceInfo = Tools.GetTruePrice(hoverItem) > 0;


### PR DESCRIPTION
typeof(ShopMenu).GetField("hoveredItem").GetValue() will be null if there is no item hovered.
Therefore null.GetValue(menu) was invoked.

Opening any vendor's Window will provoke said NPE

Original in pr #36 but without additional changes
