### PR TITLE
Added HoverInfo for Artifacts that can still be donated to the museum

### DIFF
--- a/SDVModTest/UIElements/ShowItemHoverInformation.cs
+++ b/SDVModTest/UIElements/ShowItemHoverInformation.cs
@@ -24,20 +24,20 @@ namespace UIInfoSuite.UIElements
                 Game1.mouseCursors, 
                 new Rectangle(331, 374, 15, 14), 
                 Game1.pixelZoom);
-		private readonly ClickableTextureComponent _museumIcon = new ClickableTextureComponent(
-	        "",
-	        new Rectangle(0, 0, Game1.tileSize, Game1.tileSize),
-	        "",
-	        Game1.content.LoadString("Strings\\Locations:ArchaeologyHouse_Gunther_Donate", new object[0]),
-	        Game1.getCharacterFromName("Gunther").Sprite.Texture,
-	        Game1.getCharacterFromName("Gunther").GetHeadShot(),
-	        Game1.pixelZoom);
+        private readonly ClickableTextureComponent _museumIcon = new ClickableTextureComponent(
+            "",
+            new Rectangle(0, 0, Game1.tileSize, Game1.tileSize),
+            "",
+            Game1.content.LoadString("Strings\\Locations:ArchaeologyHouse_Gunther_Donate", new object[0]),
+            Game1.getCharacterFromName("Gunther").Sprite.Texture,
+            Game1.getCharacterFromName("Gunther").GetHeadShot(),
+            Game1.pixelZoom);
 
-		private Item _hoverItem;
+        private Item _hoverItem;
         private CommunityCenter _communityCenter;
         private Dictionary<String, String> _bundleData;
-		private LibraryMuseum _libraryMuseum;
-		private readonly IModEvents _events;
+        private LibraryMuseum _libraryMuseum;
+        private readonly IModEvents _events;
 
         public ShowItemHoverInformation(IModEvents events)
         {
@@ -57,9 +57,9 @@ namespace UIInfoSuite.UIElements
                 _bundleData = Game1.content.Load<Dictionary<String, String>>("Data\\Bundles");
                 PopulateRequiredBundles();
 
-				_libraryMuseum = Game1.getLocationFromName("ArchaeologyHouse") as LibraryMuseum;
+                _libraryMuseum = Game1.getLocationFromName("ArchaeologyHouse") as LibraryMuseum;
 
-				_events.Player.InventoryChanged += OnInventoryChanged;
+                _events.Player.InventoryChanged += OnInventoryChanged;
                 _events.Display.Rendered += OnRendered;
                 _events.Display.RenderedHud += OnRenderedHud;
                 _events.Display.Rendering += OnRendering;
@@ -380,13 +380,13 @@ namespace UIInfoSuite.UIElements
 
                 if (_libraryMuseum.isItemSuitableForDonation(_hoverItem))
                 {
-	                _museumIcon.bounds.X = (int)windowPos.X - 30;
-	                _museumIcon.bounds.Y = (int)windowPos.Y - 60 + windowHeight;
-	                _museumIcon.scale = 2;
-	                _museumIcon.draw(Game1.spriteBatch);
+                    _museumIcon.bounds.X = (int)windowPos.X - 30;
+                    _museumIcon.bounds.Y = (int)windowPos.Y - 60 + windowHeight;
+                    _museumIcon.scale = 2;
+                    _museumIcon.draw(Game1.spriteBatch);
                 }
 
-				if (!String.IsNullOrEmpty(requiredBundleName))
+                if (!String.IsNullOrEmpty(requiredBundleName))
                 {
                     int num1 = (int)windowPos.X - 30;
                     int num2 = (int)windowPos.Y - 10;

--- a/SDVModTest/UIElements/ShowItemHoverInformation.cs
+++ b/SDVModTest/UIElements/ShowItemHoverInformation.cs
@@ -24,11 +24,30 @@ namespace UIInfoSuite.UIElements
                 Game1.mouseCursors, 
                 new Rectangle(331, 374, 15, 14), 
                 Game1.pixelZoom);
+        private readonly ClickableTextureComponent _artifactIcon =
+			new ClickableTextureComponent(
+				"",
+				new Rectangle(0, 0, Game1.tileSize, Game1.tileSize),
+				"",
+				Game1.content.LoadString("Strings\\UI:Collections_Artifacts", new object[0]),
+				Game1.mouseCursors,
+                new Rectangle(656, 64, 16, 16), 
+				Game1.pixelZoom);
+        private readonly ClickableTextureComponent _mineralIcon =
+			new ClickableTextureComponent(
+				"",
+				new Rectangle(0, 0, Game1.tileSize, Game1.tileSize),
+				"",
+				Game1.content.LoadString("Strings\\UI:Collections_Minerals", new object[0]),
+				Game1.mouseCursors,
+				new Rectangle(672, 64, 16, 16),
+				Game1.pixelZoom);
 
         private Item _hoverItem;
         private CommunityCenter _communityCenter;
         private Dictionary<String, String> _bundleData;
-        private readonly IModEvents _events;
+		private LibraryMuseum _libraryMuseum;
+		private readonly IModEvents _events;
 
         public ShowItemHoverInformation(IModEvents events)
         {
@@ -48,7 +67,9 @@ namespace UIInfoSuite.UIElements
                 _bundleData = Game1.content.Load<Dictionary<String, String>>("Data\\Bundles");
                 PopulateRequiredBundles();
 
-                _events.Player.InventoryChanged += OnInventoryChanged;
+				_libraryMuseum = Game1.getLocationFromName("ArchaeologyHouse") as LibraryMuseum;
+
+				_events.Player.InventoryChanged += OnInventoryChanged;
                 _events.Display.Rendered += OnRendered;
                 _events.Display.RenderedHud += OnRenderedHud;
                 _events.Display.Rendering += OnRendering;
@@ -367,7 +388,26 @@ namespace UIInfoSuite.UIElements
                     }
                 }
 
-                if (!String.IsNullOrEmpty(requiredBundleName))
+                if (_libraryMuseum.isItemSuitableForDonation(_hoverItem))
+                {
+	                ClickableTextureComponent museumIcon = _bundleIcon;
+	                switch (_hoverItem.getCategoryName())
+	                {
+		                case "Artifact":
+			                museumIcon = _artifactIcon;
+			                break;
+		                case "Mineral":
+			                museumIcon = _mineralIcon;
+			                break;
+	                }
+
+	                museumIcon.bounds.X = (int)windowPos.X - 44;
+	                museumIcon.bounds.Y = (int)windowPos.Y + 6;
+	                museumIcon.scale = 3;
+	                museumIcon.draw(Game1.spriteBatch);
+                }
+
+				if (!String.IsNullOrEmpty(requiredBundleName))
                 {
                     int num1 = (int)windowPos.X - 30;
                     int num2 = (int)windowPos.Y - 10;

--- a/SDVModTest/UIElements/ShowItemHoverInformation.cs
+++ b/SDVModTest/UIElements/ShowItemHoverInformation.cs
@@ -24,26 +24,16 @@ namespace UIInfoSuite.UIElements
                 Game1.mouseCursors, 
                 new Rectangle(331, 374, 15, 14), 
                 Game1.pixelZoom);
-        private readonly ClickableTextureComponent _artifactIcon =
-			new ClickableTextureComponent(
-				"",
-				new Rectangle(0, 0, Game1.tileSize, Game1.tileSize),
-				"",
-				Game1.content.LoadString("Strings\\UI:Collections_Artifacts", new object[0]),
-				Game1.mouseCursors,
-                new Rectangle(656, 64, 16, 16), 
-				Game1.pixelZoom);
-        private readonly ClickableTextureComponent _mineralIcon =
-			new ClickableTextureComponent(
-				"",
-				new Rectangle(0, 0, Game1.tileSize, Game1.tileSize),
-				"",
-				Game1.content.LoadString("Strings\\UI:Collections_Minerals", new object[0]),
-				Game1.mouseCursors,
-				new Rectangle(672, 64, 16, 16),
-				Game1.pixelZoom);
+		private readonly ClickableTextureComponent _museumIcon = new ClickableTextureComponent(
+	        "",
+	        new Rectangle(0, 0, Game1.tileSize, Game1.tileSize),
+	        "",
+	        Game1.content.LoadString("Strings\\Locations:ArchaeologyHouse_Gunther_Donate", new object[0]),
+	        Game1.getCharacterFromName("Gunther").Sprite.Texture,
+	        Game1.getCharacterFromName("Gunther").GetHeadShot(),
+	        Game1.pixelZoom);
 
-        private Item _hoverItem;
+		private Item _hoverItem;
         private CommunityCenter _communityCenter;
         private Dictionary<String, String> _bundleData;
 		private LibraryMuseum _libraryMuseum;
@@ -390,21 +380,10 @@ namespace UIInfoSuite.UIElements
 
                 if (_libraryMuseum.isItemSuitableForDonation(_hoverItem))
                 {
-	                ClickableTextureComponent museumIcon = _bundleIcon;
-	                switch (_hoverItem.getCategoryName())
-	                {
-		                case "Artifact":
-			                museumIcon = _artifactIcon;
-			                break;
-		                case "Mineral":
-			                museumIcon = _mineralIcon;
-			                break;
-	                }
-
-	                museumIcon.bounds.X = (int)windowPos.X - 44;
-	                museumIcon.bounds.Y = (int)windowPos.Y + 6;
-	                museumIcon.scale = 3;
-	                museumIcon.draw(Game1.spriteBatch);
+	                _museumIcon.bounds.X = (int)windowPos.X - 30;
+	                _museumIcon.bounds.Y = (int)windowPos.Y - 60 + windowHeight;
+	                _museumIcon.scale = 2;
+	                _museumIcon.draw(Game1.spriteBatch);
                 }
 
 				if (!String.IsNullOrEmpty(requiredBundleName))


### PR DESCRIPTION
I added an Icon to the hover tooltip to show if the Item can be donated to the Museum.
![grafik](https://user-images.githubusercontent.com/1161223/70395165-5531c700-19fc-11ea-8587-7aef2ea3fd71.png)

I want to change it to use another Icon to be easier understandable that the Museum is ment. I'm thinking Gunthers headshot would work nicely for that, but I'm open to suggestions.

Also I'm thinking of maybe adding an option to individually toggle this and bundles.