### PR TITLE
Fixed wrong variable naming in IconHandler

### DIFF
--- a/SDVModTest/IconHandler.cs
+++ b/SDVModTest/IconHandler.cs
@@ -31,7 +31,7 @@ namespace UIInfoSuite
             int xPosition = (int)Tools.GetWidthInPlayArea() - 70 - 48 * _amountOfVisibleIcons;
             if (Game1.player.questLog.Any())
             {
-                x -= 65;
+                xPosition -= 65;
 	        }
             ++_amountOfVisibleIcons;
             return new Point(xPosition, yPos);

--- a/SDVModTest/IconHandler.cs
+++ b/SDVModTest/IconHandler.cs
@@ -32,7 +32,7 @@ namespace UIInfoSuite
             if (Game1.player.questLog.Any())
             {
                 xPosition -= 65;
-	        }
+            }
             ++_amountOfVisibleIcons;
             return new Point(xPosition, yPos);
         }


### PR DESCRIPTION
Due to the changes in PR #28, the current state of IconHandler is not Buildable due to a wrong Variable name. This fixes the variable name and replaces the tab with spaces.