### PR TITLE
Fix for Android platform

### DIFF
--- a/SDVModTest/IconHandler.cs
+++ b/SDVModTest/IconHandler.cs
@@ -31,7 +31,7 @@ namespace UIInfoSuite
             int xPosition = (int)Tools.GetWidthInPlayArea() - 70 - 48 * _amountOfVisibleIcons;
             if (Game1.player.questLog.Any())
             {
-                x -= 65;
+                xPosition -= 65;
 	        }
             ++_amountOfVisibleIcons;
             return new Point(xPosition, yPos);

--- a/SDVModTest/Tools.cs
+++ b/SDVModTest/Tools.cs
@@ -90,15 +90,17 @@ namespace UIInfoSuite
         public static Item GetHoveredItem()
         {
             Item hoverItem = null;
-
-            for (int i = 0; i < Game1.onScreenMenus.Count; ++i)
+            if (Game1.onScreenMenus != null)
             {
-                Toolbar onScreenMenu = Game1.onScreenMenus[i] as Toolbar;
-                if (onScreenMenu != null)
+                for (int i = 0; i < Game1.onScreenMenus.Count; ++i)
                 {
-                    FieldInfo hoverItemField = typeof(Toolbar).GetField("hoverItem", BindingFlags.Instance | BindingFlags.NonPublic);
-                    hoverItem = hoverItemField.GetValue(onScreenMenu) as Item;
-                    //hoverItemField.SetValue(onScreenMenu, null);
+                    Toolbar onScreenMenu = Game1.onScreenMenus[i] as Toolbar;
+                    if (onScreenMenu != null)
+                    {
+                        FieldInfo hoverItemField = typeof(Toolbar).GetField("hoverItem", BindingFlags.Instance | BindingFlags.NonPublic);
+                        hoverItem = hoverItemField.GetValue(onScreenMenu) as Item;
+                        //hoverItemField.SetValue(onScreenMenu, null);
+                    }
                 }
             }
 

--- a/SDVModTest/UIElements/ExperienceBar.cs
+++ b/SDVModTest/UIElements/ExperienceBar.cs
@@ -9,7 +9,6 @@ using StardewValley.Tools;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Media;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
@@ -46,7 +45,7 @@ namespace UIInfoSuite.UIElements
         private bool _showLevelUpAnimation = true;
         private bool _showExperienceBar = true;
         private readonly IModHelper _helper;
-        private SoundPlayer _player;
+        private object _player;
 
         private LevelExtenderInterface _levelExtenderAPI;
 
@@ -62,7 +61,7 @@ namespace UIInfoSuite.UIElements
             try
             {
                 path = Path.Combine(_helper.DirectoryPath, "LevelUp.wav");
-                _player = new SoundPlayer(path);
+                _player = Type.GetType("System.Media.SoundPlayer")?.GetConstructor(new Type[] { }).Invoke(new object[] { });
                 //path = path.Replace(Environment.CurrentDirectory, "");
                 //path = path.TrimStart(Path.DirectorySeparatorChar);
                 //_soundEffect = SoundEffect.FromStream(TitleContainer.OpenStream(path)).CreateInstance();
@@ -209,7 +208,7 @@ namespace UIInfoSuite.UIElements
                 Task.Factory.StartNew(() =>
                 {
                     Thread.Sleep(100);
-                    _player.Play();
+                    Type.GetType("System.Media.SoundPlayer")?.GetMethod("Play").Invoke(this._player, new object[] { });
                 });
 
                 Task.Factory.StartNew(() =>

--- a/SDVModTest/UIElements/LocationOfTownsfolk.cs
+++ b/SDVModTest/UIElements/LocationOfTownsfolk.cs
@@ -215,7 +215,7 @@ namespace UIInfoSuite.UIElements
         {
             if (Game1.activeClickableMenu is GameMenu gameMenu)
             {
-                if (gameMenu.currentTab == 3)
+                if (gameMenu.currentTab == (Constants.TargetPlatform == GamePlatform.Android ? 4 : 3))
                 {
                     List<String> namesToShow = new List<string>();
                     foreach (var character in _townsfolk)

--- a/SDVModTest/UIElements/ShopHarvestPrices.cs
+++ b/SDVModTest/UIElements/ShopHarvestPrices.cs
@@ -42,7 +42,8 @@ namespace UIInfoSuite.UIElements
             // draw shop harvest prices
             if (Game1.activeClickableMenu is ShopMenu menu)
             {
-                if (menu.hoveredItem is Item hoverItem)
+                object item = _helper.Reflection.GetField<object>(menu, "hoveredItem").GetValue();
+                if (item is Item hoverItem)
                 {
                     String text = string.Empty;
                     bool itemHasPriceInfo = Tools.GetTruePrice(hoverItem) > 0;
@@ -66,8 +67,9 @@ namespace UIInfoSuite.UIElements
                                 1);
                         text = "    " + temp.Price;
                     }
-                    
-                    var heldItem = menu.heldItem as Item;
+
+                    item = _helper.Reflection.GetField<object>(menu, "heldItem").GetValue();
+                    var heldItem = item as Item;
                     if (heldItem == null)
                     {
                         int value = 0;
@@ -162,7 +164,7 @@ namespace UIInfoSuite.UIElements
                                 getHoveredItemExtraItemIndex.Invoke<int>(new object[0]),
                                 getHoveredItemExtraItemAmount.Invoke<int>(new object[0]),
                                 null,
-                                menu.hoverPrice);
+                                _helper.Reflection.GetField<Int32>(menu, "hoverPrice").GetValue());
                         }
                     }
                 }

--- a/SDVModTest/UIElements/ShopHarvestPrices.cs
+++ b/SDVModTest/UIElements/ShopHarvestPrices.cs
@@ -42,8 +42,7 @@ namespace UIInfoSuite.UIElements
             // draw shop harvest prices
             if (Game1.activeClickableMenu is ShopMenu menu)
             {
-                object item = _helper.Reflection.GetField<object>(menu, "hoveredItem").GetValue();
-                if (item is Item hoverItem)
+                if (menu.hoveredItem is Item hoverItem)
                 {
                     String text = string.Empty;
                     bool itemHasPriceInfo = Tools.GetTruePrice(hoverItem) > 0;
@@ -68,8 +67,7 @@ namespace UIInfoSuite.UIElements
                         text = "    " + temp.Price;
                     }
 
-                    item = _helper.Reflection.GetField<object>(menu, "heldItem").GetValue();
-                    var heldItem = item as Item;
+                    var heldItem = menu.heldItem as Item;
                     if (heldItem == null)
                     {
                         int value = 0;
@@ -164,7 +162,7 @@ namespace UIInfoSuite.UIElements
                                 getHoveredItemExtraItemIndex.Invoke<int>(new object[0]),
                                 getHoveredItemExtraItemAmount.Invoke<int>(new object[0]),
                                 null,
-                                _helper.Reflection.GetField<Int32>(menu, "hoverPrice").GetValue());
+                                menu.hoverPrice);
                         }
                     }
                 }

--- a/SDVModTest/UIElements/ShowAccurateHearts.cs
+++ b/SDVModTest/UIElements/ShowAccurateHearts.cs
@@ -103,7 +103,7 @@ namespace UIInfoSuite.UIElements
                             }
                         }
 
-                        String hoverText = (string)gameMenu.GetType().GetField("hoverText", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)?.GetValue(gameMenu);
+                        String hoverText = gameMenu.hoverText;
                         IClickableMenu.drawHoverText(
                             Game1.spriteBatch,
                             hoverText,

--- a/SDVModTest/UIElements/ShowAccurateHearts.cs
+++ b/SDVModTest/UIElements/ShowAccurateHearts.cs
@@ -103,7 +103,7 @@ namespace UIInfoSuite.UIElements
                             }
                         }
 
-                        String hoverText = gameMenu.hoverText;
+                        String hoverText = (string)gameMenu.GetType().GetField("hoverText", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)?.GetValue(gameMenu);
                         IClickableMenu.drawHoverText(
                             Game1.spriteBatch,
                             hoverText,


### PR DESCRIPTION
There is no System.Media namespace in Monoandroid platform, using reflection instead to prevent crash.