### PR TITLE
Can define hierarchy on options page

### DIFF
--- a/SDVModTest/Options/ModOptionsCheckbox.cs
+++ b/SDVModTest/Options/ModOptionsCheckbox.cs
@@ -13,30 +13,28 @@ namespace UIInfoSuite.Options
 {
     class ModOptionsCheckbox : ModOptionsElement
     {
-        private const int PixelSize = 9;
-
         private readonly Action<bool> _toggleOptionsDelegate;
         private bool _isChecked;
         private readonly IDictionary<String, String> _options;
         private readonly String _optionKey;
+        private bool _canClick => !(_parent is ModOptionsCheckbox) || (_parent as ModOptionsCheckbox)._isChecked;
 
         public ModOptionsCheckbox(
-            String label, 
-            int whichOption, 
-            Action<bool> toggleOptionDelegate, 
-            IDictionary<String, String> options, 
-            String optionKey, 
-            bool defaultValue = true, 
-            int x = -1, 
-            int y = -1)
-            : base(label, x, y, PixelSize * Game1.pixelZoom, PixelSize * Game1.pixelZoom, whichOption)
+            String label,
+            int whichOption,
+            Action<bool> toggleOptionDelegate,
+            IDictionary<String, String> options,
+            String optionKey,
+            ModOptionsCheckbox parent = null,
+            bool defaultValue = true)
+            : base(label, whichOption, parent)
         {
             _toggleOptionsDelegate = toggleOptionDelegate;
             _options = options;
             _optionKey = optionKey;
 
             if (!_options.ContainsKey(_optionKey))
-                _options[_optionKey] = defaultValue.ToString();
+                _options[_optionKey] = defaultValue ? "true" : "false";
 
             _isChecked = _options[_optionKey].SafeParseBool();
             _toggleOptionsDelegate(_isChecked);

--- a/SDVModTest/Options/ModOptionsElement.cs
+++ b/SDVModTest/Options/ModOptionsElement.cs
@@ -13,33 +13,33 @@ namespace UIInfoSuite.Options
 {
     public class ModOptionsElement
     {
-        private const int DefaultX = 8;
-        private const int DefaultY = 4;
-        private const int DefaultPixelSize = 9;
+        protected const int DefaultX = 8;
+        protected const int DefaultY = 4;
+        protected const int DefaultPixelSize = 9;
+
         private Rectangle _bounds;
         private String _label;
         private int _whichOption;
-        protected bool _canClick = true;
+
+        protected readonly ModOptionsElement _parent;
 
         public Rectangle Bounds { get { return _bounds; } }
 
-        public ModOptionsElement(String label)
-            : this(label, -1, -1, DefaultPixelSize * Game1.pixelZoom, DefaultPixelSize * Game1.pixelZoom)
+        public ModOptionsElement(string label, int whichOption = -1, ModOptionsElement parent = null)
         {
+            int x = DefaultX * Game1.pixelZoom;
+            int y = DefaultY * Game1.pixelZoom;
+            int width = DefaultPixelSize * Game1.pixelZoom;
+            int height = DefaultPixelSize * Game1.pixelZoom;
 
-        }
-
-        public ModOptionsElement(String label, int x, int y, int width, int height, int whichOption = -1)
-        {
-            if (x < 0)
-                x = DefaultX * Game1.pixelZoom;
-
-            if (y < 0)
-                y = DefaultY * Game1.pixelZoom;
+            if (parent != null)
+                x += DefaultX * 2 * Game1.pixelZoom;
 
             _bounds = new Rectangle(x, y, width, height);
             _label = label;
             _whichOption = whichOption;
+
+            _parent = parent;
         }
 
         public virtual void ReceiveLeftClick(int x, int y)
@@ -74,7 +74,7 @@ namespace UIInfoSuite.Options
                     _label, 
                     Game1.dialogueFont, 
                     new Vector2(slotX + _bounds.X + _bounds.Width + Game1.pixelZoom * 2, slotY + _bounds.Y), 
-                    _canClick ? Game1.textColor : Game1.textColor * 0.33f, 
+                    Game1.textColor, 
                     1f, 
                     0.1f);
             }


### PR DESCRIPTION
This commit does not change anything in the way the mod works, only reorganizes the code of the Option component and adds the possibility do define parent options. I tried to keep changes to the minimum, most of them are coming from the new parent option and because some properties needs to be accessed in a child/parent class too.

![image](https://user-images.githubusercontent.com/10620868/110362817-1006a580-8042-11eb-8e60-c2f42d016d81.png)

![image](https://user-images.githubusercontent.com/10620868/110362851-1bf26780-8042-11eb-9868-8ce22e96aafa.png)

If this change gets accepted I will add further options which enable fine-tuning thw way the mod works. For example, the feature to show exact value for the luck has been asked multiple times on the forum and I saw you rejected it, because it breaks immersion, but this way we can add the option to use it (every option I add defaults the the way the mod already works).